### PR TITLE
Improve consistency in color file export  and simplify marker gene fallback logic

### DIFF
--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -5335,7 +5335,7 @@ def scanpyToCellbrowser(adata, path, datasetName, metaFields=None, clusterField=
         logging.warn("No valid embeddings were found in anndata.obsm but at least one array of coordinates is usually required. Keys obsm: %s" % (coordFields))
 
     ##Check for cluster markers
-    if (markerField not in adata.uns or clusterField is not None) and not skipMarkers:
+    if markerField not in adata.uns and not skipMarkers:
         logging.warn("Couldnt find list of cluster marker genes in the h5ad file in adata.uns with the key '%s'. "
             "In the future, from Python, try running sc.tl.rank_genes_groups(adata) to "
             "create the cluster annotation and write the h5ad file then." % markerField)


### PR DESCRIPTION
This PR addresses two related issues in the `scanpyToCellbrowser`:

1. **Standardize color file paths in config output**  
   Updates the `exportScanpyOneFieldColor` function to record only the filename (not the relative path) in the config entry. This ensures consistency with other file references and prevents incorrect path resolution when files are later accessed via absolute paths.

2. **Simplify fallback logic for marker gene computation**  
   Refines the conditional logic that triggers fallback computation of marker genes. Marker gene ranking is now only computed when the marker data is missing and not explicitly skipped. Previously, this logic could be triggered by the presence of `clusterField`, even if `markerField` was already present, leading to redundant or unintended recomputation.