### PR TITLE
Sort metadata values (refs: #10):

### DIFF
--- a/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
@@ -1832,11 +1832,17 @@ var cellbrowser = function() {
             // it's an enum field
             $('#tpSelectValue_'+rowIdx).hide();
             $('#tpSelectMetaValueEnum_'+rowIdx).empty();
-            for (var i = 0; i < valCounts.length; i++) {
-                //var valName = valCounts[i][0];
-                var valLabel = shortLabels[i];
-                $('#tpSelectMetaValueEnum_'+rowIdx).append("<option value='"+i+"'>"+valLabel+"</option>");
+            
+            // sort values by label, but keep track of original index
+            var sorted = shortLabels.map((label, i) => ({label, idx: i}));
+            sorted.sort((a, b) => a.label.localeCompare(b.label, undefined, {numeric: true}));
+
+            for (var i = 0; i < sorted.length; i++) {
+                var valIndex = sorted[i].idx;
+                var valLabel = sorted[i].label;
+                $('#tpSelectMetaValueEnum_'+rowIdx).append("<option value='"+valIndex+"'>"+valLabel+"</option>");
             }
+
             $('#tpSelectMetaValueEnum_'+rowIdx).show();
         }
     }


### PR DESCRIPTION
I made a minor change in the function findCellsUpdateMetaCombo to solve the issue described here: https://github.com/ucscGenomeBrowser/cellBrowser/issues/10

I create a mapping called `sorted` to store each value in `shortLabels` along with its original index. Then I sort the mapping by the values in `shortLabel`. Tested this on a private cellbrowser server and confirmed that it sorts the values as desired. 