### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,6 @@
 [codespell]
-skip = .git,.gitignore,.gitattributes,*.pdf,*.svg,*.css,*.min.*,*-min.*,*.pack.js,*.json,*.json.gz,*.gz,*.tsv,*.csv,*.png,*.jpg,*.ico,*.woff,*.woff2,*.ttf,*.eot,*.h5ad,*.rds,*.tags,*.sizes,*/ext/*,*/node_modules/*,*/cellbrowserData/*,*/sampleData/*,versioneer.py,*/_version.py,*/build/*,docs/_build/*,docs/build/*,docs/images/*,*/cbWeb/genes/*
+skip = .git,.git-meta,.gitignore,.gitattributes,*.pdf,*.svg,*.css,*.min.*,*-min.*,*.pack.js,*.json,*.json.gz,*.gz,*.tsv,*.csv,*.png,*.jpg,*.ico,*.woff,*.woff2,*.ttf,*.eot,*.h5ad,*.rds,*.tags,*.sizes,*/ext/*,*/node_modules/*,*/cellbrowserData/*,*/sampleData/*,versioneer.py,*/_version.py,*/build/*,docs/_build/*,docs/build/*,docs/images/*,*/cbWeb/genes/*,*/ucsc/ezid.py
 check-hidden = true
 # ignore-regex =
-# ignore-words-list =
+# ore - JavaScript regex variable name (/^0/) in natural-sort code in cellBrowser.js
+ignore-words-list = ore

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = .git,.gitignore,.gitattributes,*.pdf,*.svg,*.css,*.min.*,*-min.*,*.pack.js,*.json,*.json.gz,*.gz,*.tsv,*.csv,*.png,*.jpg,*.ico,*.woff,*.woff2,*.ttf,*.eot,*.h5ad,*.rds,*.tags,*.sizes,*/ext/*,*/node_modules/*,*/cellbrowserData/*,*/sampleData/*,versioneer.py,*/_version.py,*/build/*,docs/_build/*,docs/build/*,docs/images/*,*/cbWeb/genes/*
+check-hidden = true
+# ignore-regex =
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ If you use the UCSC Cell Browser in your research, please cite
 If you are also using data from a specific dataset we host, please also cite
 the original authors of that dataset (visible under 'Info & Download' while viewing that dataset).
 
-This is a viewer for a static, precomputed layout. If you're looking for an interative layout, where you can 
+This is a viewer for a static, precomputed layout. If you're looking for an interactive layout, where you can 
 move the cells around and run some algorithms interactively, try Chan-Zuckerberg's own cellxgene or Spring.
 Another website with both datasets and some analysis is `Scope <http://scope.aertslab.org/>`_. There are many other
 similar websites now, usually with a few dozen datasets.

--- a/docs/bulk.rst
+++ b/docs/bulk.rst
@@ -30,4 +30,4 @@ All datasets also have a meta.tsv file with the cell-level metadata.
 
 The json file should be very self-explanatory.
 
-Please let us know if you use this. We love hearing feedback and like to report re-use of the dataset collection to NIMH.
+Please let us know if you use this. We love hearing feedback and like to report reuse of the dataset collection to NIMH.

--- a/docs/combine.rst
+++ b/docs/combine.rst
@@ -1,7 +1,7 @@
 ``cbTool``: combine and convert your data
 =====
 
-The script ``cbTool`` included in the Cell Browser package includes a number of utilties
+The script ``cbTool`` included in the Cell Browser package includes a number of utilities
 for combining or converting your data. These different functions and how to use them are
 described below. 
 

--- a/docs/dataDesc.rst
+++ b/docs/dataDesc.rst
@@ -71,6 +71,6 @@ The following tags contain a list of key-value information::
 - ``supplFiles``: additional files that should be copied and be shown in the 'Download' section, like protocols, Seurat 
   or Scanpy files, e.g. ``supplFiles=[{'file':'seurat3.rds', 'label':'Seurat3 RDS'}]``
 
-The folllowing tags contain only ``True`` or ``False``::
+The following tags contain only ``True`` or ``False``::
 
 - ``hideDownload=True``: do not show the download instructions.

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -20,7 +20,7 @@ You can go from an RDS file to cell browser for a dataset in three easy steps:
 Step 1: Export an RDS file of your Seurat object
 """"
 
-From within R, run this command to create an RDS file fo your dataset::
+From within R, run this command to create an RDS file of your dataset::
 
   saveRDS(objName, "myDataset.rds")
 

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -82,7 +82,7 @@ Or, if you don't have a webserver already, start the built-in one:
   cbBuild -o /myHtmlFiles -p 8888
 
 
-How to configue a basic cbSeurat pipeline
+How to configure a basic cbSeurat pipeline
 ^^^^
 
 Running ``cbSeurat`` will run a basic Seurat pipeline with the default settings. ``cbSeurat`` can be configured through a `seurat.conf <https://github.com/maximilianh/cellBrowser/blob/master/src/cbPyLib/cellbrowser/sampleConfig/seurat.conf>`_.
@@ -185,7 +185,7 @@ Next, go into the output directory specified in the ``cbScanpy`` command and bui
   cd scanpy-out
   cbBuild -o ~/public_html/cb
 
-How to configue a basic cbScanpy pipeline
+How to configure a basic cbScanpy pipeline
 ^^^^
 
 Running ``cbSeurat`` will run a basic Scanpy pipeline with the default settings. ``cbScanpy`` can be configured through a `scanpy.conf <https://github.com/maximilianh/cellBrowser/blob/master/src/cbPyLib/cellbrowser/sampleConfig/scanpy.conf>`_.
@@ -398,7 +398,7 @@ You will the following three files:
 
 * Expression matrix with cell names as columns and peak ranges as rows. 
 * Cell annotations/metadata
-* Layout coordinats (e.g. UMAP)
+* Layout coordinates (e.g. UMAP)
 
 The peaks must be encoded in the expression matrix in the format chr:start-end, e.g. "chr1:1000-2000".
 
@@ -414,8 +414,8 @@ Examples:
 
 ::
 
- cbGenes fetch gencode-34        # geneId -> symbol mapping for human gencode relase 34
- cbGenes fetch hg38.gencode-34   # gene -> chrom mapping for human gencode relase 34
+ cbGenes fetch gencode-34        # geneId -> symbol mapping for human gencode release 34
+ cbGenes fetch hg38.gencode-34   # gene -> chrom mapping for human gencode release 34
 
 Both files are required for this to work.
 

--- a/docs/scanpy.rst
+++ b/docs/scanpy.rst
@@ -11,7 +11,7 @@ A standard Scanpy pipeline
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Requirements: Python3 with Scanpy installed, see their `installation instructions <https://scanpy.readthedocs.io/en/latest/installation.html>`_ for information about setting up Scanpy.
-As part of the Scanpy installion process, ensure that the igraph library is also installed.
+As part of the Scanpy installation process, ensure that the igraph library is also installed.
 It's needed for the most basic scanpy features even though it's not an official requirement.
 The command ``pip install scanpy[louvain]`` will make sure that igraph is installed.
 

--- a/src/cbPyLib/cellbrowser/cbWeb/js/cbData.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cbData.js
@@ -185,7 +185,7 @@ var cbUtil = (function () {
         var binData = this.response;
 
         if (!binData) {
-          alert("internal error when loading "+url+": no reponse from server?");
+          alert("internal error when loading "+url+": no response from server?");
           return;
         }
 
@@ -266,7 +266,7 @@ var cbUtil = (function () {
     };
 
     my.searchKeys = function(geneIdx, searchStr)  {
-        /* search the keys of an object for matches. Uses a strategy adapted for gene identifers and symbols:
+        /* search the keys of an object for matches. Uses a strategy adapted for gene identifiers and symbols:
          * - ignore case
          * - prefix search
          * - if not match, try suffix search
@@ -352,7 +352,7 @@ var cbUtil = (function () {
     };
 
     my.arrSub = function (a, b) {
-        /* substract array b from array a, modifying a in place. Return a. */
+        /* subtract array b from array a, modifying a in place. Return a. */
         if (a.length !== b.length)
             alert("cbUtil.arrAdd: input arrays must have same size");
         for (var i=0; i < a.length; i++)
@@ -361,7 +361,7 @@ var cbUtil = (function () {
     };
 
     my.arrSubMult = function (a, bArrs) {
-        /* substract all arrays in bArrs from array a, modifying a in place. Return a. */
+        /* subtract all arrays in bArrs from array a, modifying a in place. Return a. */
         for (var bi=0; bi < bArrs.length; bi++) {
             var a = cbUtil.arrSub(a, bArrs[bi]);
         }
@@ -410,7 +410,7 @@ function CbDbFile(url) {
     // indices, resolve sample indices to sample names load meta for a given
     // cell index
     var self = this; // this has two conflicting meanings in javascript.
-    // To make it a little more readble, we use 'self' to refer to object variables and 'this' to refer to the calling object
+    // To make it a little more readable, we use 'self' to refer to object variables and 'this' to refer to the calling object
 
     const DEBUG = false;
 
@@ -671,14 +671,14 @@ function CbDbFile(url) {
 
             var bytes = comprBytes; // some Apache/InternetBrowser combinations silently uncompress
             var comprView = new Uint8Array(comprBytes);
-            // magic bytes of gzip are 1f, 8b, and we assume little endianess
+            // magic bytes of gzip are 1f, 8b, and we assume little endianness
             if (comprView[0]===0x1f && comprView[1]===0x8b) {
                 try {
                     bytes = pako.ungzip(comprBytes);
                 }
                 catch(err) {
                     alert("Error when decompressing a file. This has to do with your Apache config or your "+
-                             " internet browser and incorrect compresssion http headers. "+
+                             " internet browser and incorrect compression http headers. "+
                              "Please contact cells@ucsc.edu, we can help you solve this. "+err);
                 }
             }
@@ -1020,15 +1020,15 @@ function CbDbFile(url) {
      * - chr1|1000|2000 chrom range
      * - sums of either of these, e.g. PITX1+OTX2 or chr1|1000|2000+chr2|1000|2000
      * - a single gene or locus name, prefixed by "+", to add to the current array
-     * - a single gene or locus name, prefixed by "-", to substract from the current array
+     * - a single gene or locus name, prefixed by "-", to subtract from the current array
 
      * "strategy" can be "cells" or "range" or "none". If "cells", bins will have an ideally equal number of cells.
-     * if "range", bins will have an equal range between min-max (and somtimes no cells at all). If undefined,
+     * if "range", bins will have an equal range between min-max (and sometimes no cells at all). If undefined,
      * is "cells". "none" switches off discretization.
      * */
 
         function allRangesDone() {
-            /* sum/substract all arrays and call the callback */
+            /* sum/subtract all arrays and call the callback */
             // create a summarized gene desc
             let geneDescs = [];
             let arrs = [];

--- a/src/cbPyLib/cellbrowser/cbWeb/js/cbData.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cbData.js
@@ -233,7 +233,7 @@ var cbUtil = (function () {
             if (this._arrType==="comprText") {
                 var arr = pako.ungzip(binData);
                 // https://stackoverflow.com/questions/6965107/converting-between-strings-and-arraybuffers
-                // convert byte array to strin
+                // convert byte array to string
                 // I used the apply() function originally, that's more compatible, but leads to a
                 // stack overflow in bigger datasets
                 //binData = String.fromCharCode.apply(null, arr);

--- a/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
@@ -4468,7 +4468,7 @@ var cellbrowser = function() {
         if (newRadius)
             opts["radius"] = newRadius;
 
-        // label text can be overriden by the user cart
+        // label text can be overridden by the user cart
         var labelField = db.conf.labelField;
 
         if (clusterInfo) {
@@ -5203,7 +5203,7 @@ var cellbrowser = function() {
     }
 
     function getTextWidth(text, font) {
-        // re-use canvas object for better performance
+        // reuse canvas object for better performance
         // http://stackoverflow.com/questions/118241/calculate-text-width-with-javascript
         var canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement("canvas"));
         var context = canvas.getContext("2d");
@@ -6497,7 +6497,7 @@ var cellbrowser = function() {
         if (sortBy===undefined && oldSortBy!==undefined)
             sortBy = oldSortBy;
 
-        // default sorting can be specfied with "sortBy" in cellbrowser.conf
+        // default sorting can be specified with "sortBy" in cellbrowser.conf
         if (sortBy===undefined && metaInfo.sortBy)
             sortBy = metaInfo.sortBy;
         if (sortBy!==undefined && sortBy!=="freq" && sortBy!=="name" && sortBy!=="none") {
@@ -8612,7 +8612,7 @@ var cellbrowser = function() {
                 alert("This gene is already on the plot");
         }
 
-        // pull out necesssary data from exprData object
+        // pull out necessary data from exprData object
         let cellCounts = exprData.cellCounts;
 
         let rows = exprData.rows; // one row per meta data value (e.g. cell type)
@@ -9559,7 +9559,7 @@ var cellbrowser = function() {
               },
               {
                 element: document.querySelector('#tpGeneTab'),
-                intro: "Color by gene: Click a gene from the list of pre-selected dataset genes or search for a gene in the dropdown to color by it.<br>",
+                intro: "Color by gene: Click a gene from the list of preselected dataset genes or search for a gene in the dropdown to color by it.<br>",
                 position: 'auto'
               },
               {
@@ -10003,7 +10003,7 @@ var cellbrowser = function() {
         var ret = {};
         ret.list = countList;
         ret.isSortedByName = isSortedByName;
-        // pallette should be a gradient for data types where this makes sense
+        // palette should be a gradient for data types where this makes sense
         return ret;
     }
 
@@ -11998,7 +11998,7 @@ function onClusterNameHover(clusterName, nameIdx, ev, isLegend, doScroll, intKey
            urlVars = {}; // ignore all current vars
        }
 
-       // overwrite everthing that we got
+       // overwrite everything that we got
        for (var key in vars) {
            var val = vars[key];
            if (val===null || val==="") {

--- a/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
@@ -6377,7 +6377,7 @@ var cellbrowser = function() {
     function likeEmptyString(label) {
     /* some special values like "undefined" and empty string get colored in grey  */
         return (label===null || label.trim()==="" || label==="none" || label==="None" || label==="unknown" ||
-            label==="nd" || label==="n.d." ||
+            label==="nd" || label==="n.d." || // codespell:ignore nd
             label==="Unknown" || label==="NaN" || label==="NA" || label==="undefined" || label==="Na");
     }
 

--- a/src/cbPyLib/cellbrowser/cbWeb/js/maxPlot.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/maxPlot.js
@@ -582,7 +582,7 @@ function MaxPlot(div, top, left, width, height, args) {
         /**
          * Gets the location of the specified GLSL attribute
          * 
-         * @param {String} name Attribue name
+         * @param {String} name Attribute name
          * @returns Attribute location
          */
         const getAttribute = (name) => {
@@ -1401,7 +1401,7 @@ function MaxPlot(div, top, left, width, height, args) {
         const spanX = maxX - minX;
         const spanY = maxY - minY;
 
-        // Scale coordiantes to fit [-1, 1] (accounting for the radius)
+        // Scale coordinates to fit [-1, 1] (accounting for the radius)
         const margin = self.port.radius;
         const canvas = self.canvas;
         const trueHalfSpanX = 1 - ((2 * margin) / canvas.width);
@@ -1995,7 +1995,7 @@ function MaxPlot(div, top, left, width, height, args) {
        debug("Drawing "+coordColors.length+" coords with drawImg renderer, radius="+radius);
 
        var diam = Math.round(2 * radius);
-       var tileWidth = diam + 2; // must add one pixel on each side, space for antialising
+       var tileWidth = diam + 2; // must add one pixel on each side, space for antialiasing
        var tileHeight = tileWidth; // otherwise circles look cut off
 
        let templates = makeCircleTemplates(radius, tileWidth, tileHeight, colors, fatIdx);
@@ -2512,7 +2512,7 @@ function MaxPlot(div, top, left, width, height, args) {
     this.setCoordsWebGL = function() {
         /* Scale coords and labels to fit to WebGL clip space. Bind the results to the a_Position attribute */
 
-        // Scale coordiantes to clip space
+        // Scale coordinates to clip space
         const coords = scaleCoordsWebGL(self.coords.orig);
         self.coords.gl = coords;
 
@@ -3748,7 +3748,7 @@ function MaxPlot(div, top, left, width, height, args) {
             if (isHidden(pxX, pxY, i))
                continue;
 
-            // If webGL is being used, we have to translate the clip space coordiante to pixel space
+            // If webGL is being used, we have to translate the clip space coordinate to pixel space
             if(self.usesWebGL()) {
                 const [glX, glY] = self.port.projection.multiply(pxX, pxY);
                 pxX = (glX + 1) / 2 * self.canvas.width;
@@ -4410,7 +4410,7 @@ function MaxPlot(div, top, left, width, height, args) {
         plot2.onActiveChange = self.onActiveChange;
 
         if(self.usesWebGL()) {
-            // Initialiaze WebGL buffers on child plot
+            // Initialize WebGL buffers on child plot
             plot2.bindBuffer(2, plot2.a_Position, plot2.coords.gl, plot2.ctx.FLOAT);
 
             plot2.bindColors();     // binds a_Color and a_ColID
@@ -4651,7 +4651,7 @@ class Matrix4 {
         [sl, sb] = this.getCoordinates(l, b);
         [sr, st] = this.getCoordinates(r, t);
     } else {
-        // No rescale requested. Just use given coordiantes
+        // No rescale requested. Just use given coordinates
         [sl, sb] = [l, b];
         [sr, st] = [r, t];
     }

--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -3035,7 +3035,7 @@ def parseMarkerTable(filename, geneToSym):
         try:
             scoreVal = float(row[scoreIdx])
         except ValueError:
-            logging.error("File %s, column %d: value is not a number but we expect a number in this colum."
+            logging.error("File %s, column %d: value is not a number but we expect a number in this column."
                     "Columns should be: cluster, gene, score. '%s' is not a score`" %
                     (filename, scoreIdx+1, row[scoreIdx]))
             raise
@@ -5453,7 +5453,7 @@ def scanpyToCellbrowser(adata, path, datasetName, metaFields=None, clusterField=
     from the AnnData object (other than 'louvain' to also save (eg: batches, ...)).
     This can also be a dict of name -> label, if you want to have more human-readable names.
     :param nb_marker: number of cluster markers to store. Default: 50
-    :param atac: assume that the file is an ATAC seq file, chnages the cellbrowser.conf output file
+    :param atac: assume that the file is an ATAC seq file, changes the cellbrowser.conf output file
     :param layer: specify the layer to use in the anndata object
 
     """
@@ -5521,7 +5521,7 @@ def scanpyToCellbrowser(adata, path, datasetName, metaFields=None, clusterField=
 
     ##Check for cluster markers
     if (markerField not in adata.uns or clusterField is not None) and not skipMarkers:
-        logging.warn("Couldnt find list of cluster marker genes in the h5ad file in adata.uns with the key '%s'. "
+        logging.warn("Couldn't find list of cluster marker genes in the h5ad file in adata.uns with the key '%s'. "
             "In the future, from Python, try running sc.tl.rank_genes_groups(adata) to "
             "create the cluster annotation and write the h5ad file then." % markerField)
         logging.info("Filtering for >5 cells then do sc.tl.rank_genes_groups for meta field '%s'" % clusterField)
@@ -6107,7 +6107,7 @@ def serve(outDir, port):
 
 def serveDirect(outDir, port):
     """ run a webserver on localhost with a port, fork/detach as a daemon, and
-    write PID into <tempdir>/cellbrowser.pid. NOT USED FOR NOW - Jupyther/ipython/Rstudio don't like this  """
+    write PID into <tempdir>/cellbrowser.pid. NOT USED FOR NOW - Jupyter/ipython/Rstudio don't like this  """
     # mostly copied from
     # http://code.activestate.com/recipes/66012-fork-a-daemon-process-on-unix/
     # do the UNIX double-fork magic, see Stevens' "Advanced 
@@ -6259,7 +6259,7 @@ def importLoom(inFname, reqCoords=False):
     return ad
 
 def adataStringFix(adata):
-    " some h5ad files read from 10X MTX have bytestrings in them instread of normal strings "
+    " some h5ad files read from 10X MTX have bytestrings in them instead of normal strings "
     if not type(adata.var.index[0])==str:
         logging.warn("Workaround: Converting byte strings in adata.var.index to normal strings")
         adata.var.index = adata.var.index.str.decode("utf-8")
@@ -6953,7 +6953,7 @@ def addMetaToAnnData(adata, fname):
         logging.info("%d meta data columns after setting in anndata object" % len(adata.obs.index))
 
     except ValueError:
-        logging.warn("Could not merge h5ad and meta data, skipping h5ad meta and using only provided meta. Most likly this happens when the field names in the h5ad and the meta file overlap")
+        logging.warn("Could not merge h5ad and meta data, skipping h5ad meta and using only provided meta. Most likely this happens when the field names in the h5ad and the meta file overlap")
         adata.obs = df2
 
     return adata
@@ -7061,7 +7061,7 @@ def cbScanpy(matrixFname, inMeta, inCluster, confFname, figDir, logFname, skipMa
 
     #useRaw = conf["useRaw"]
     #if useRaw and not bigDataset:
-        #adata.raw = adata # this is doing much more than assigning, it calls implicitely a function that copies
+        #adata.raw = adata # this is doing much more than assigning, it calls implicitly a function that copies
         ## a few things around. See the anndata source code under basic.py
     #else:
         #bigDataset = True

--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -1140,7 +1140,7 @@ def typeForStrings(strings):
         return "float"
     return "int"
 
-emptyVals = ["", "null", "none", "None", "unknown", "nd", "n.d.", "Unknown", "NaN", "NA", "undefined", "Na", "na"]
+emptyVals = ["", "null", "none", "None", "unknown", "nd", "n.d.", "Unknown", "NaN", "NA", "undefined", "Na", "na"]  # codespell:ignore nd
 
 def likeEmptyString(val):
     " returns true if string is a well-known synonym of 'unknown' or 'NaN'. ported from cellbrowser.js "
@@ -6795,7 +6795,7 @@ def cbMake(outDir, devMode=False):
     cbUpgrade(outDir, devMode=devMode)
 
 #def makeDatasetListJsons(datasets, outDir):
-#    " recusively write dataset.json files from datasets to outDir "
+#    " recursively write dataset.json files from datasets to outDir "
 #    for dataset in datasets:
 #        if "children" in dataset:
 #            makeDatasetListJsons(dataset["children"], join(outDir, dataset["name"]))

--- a/src/cbPyLib/cellbrowser/convert.py
+++ b/src/cbPyLib/cellbrowser/convert.py
@@ -483,7 +483,7 @@ def importCellrangerMatrix(inDir, outDir):
 
     # ugly code warning
     if len(matFnames1)!=0:
-        # cellranger 1/2 mtx files are not gziped
+        # cellranger 1/2 mtx files are not gzipped
         assert(len(matFnames1)==1)
         matFname = matFnames1[0]
         logging.info("Found %s" % matFname)

--- a/src/cbPyLib/cellbrowser/genes.py
+++ b/src/cbPyLib/cellbrowser/genes.py
@@ -35,8 +35,8 @@ def cbGenes_parseArgs():
 
     Examples (common):
     %prog fetch                   # show the files that are available for the 'build' command
-    %prog fetch gencode-34        # geneId -> symbol mapping for human gencode relase 34
-    %prog fetch hg38.gencode-34   # gene -> chrom mapping for human gencode relase 34
+    %prog fetch gencode-34        # geneId -> symbol mapping for human gencode release 34
+    %prog fetch hg38.gencode-34   # gene -> chrom mapping for human gencode release 34
     %prog ls
     %prog guess genes.txt mouse   # guess the best gencode version for this file
     %prog check features.tsv.gz gencode-40 # check if the genes match gencode-40 and which ones don't

--- a/src/cbPyLib/cellbrowser/hubmaker.py
+++ b/src/cbPyLib/cellbrowser/hubmaker.py
@@ -182,7 +182,7 @@ def writeBarChartDesc(hubDir, hubName, hubUrl, refHtmlFname):
 
 <h2>Methods</h2>
 <p>The annotation files that associate cells to cluster names were parsed. Then the expression matrix was read.
-For each gene, the expresssion values for all cells from a cluster were read and sorted.
+For each gene, the expression values for all cells from a cluster were read and sorted.
 The median of this sorted list was written to a bigBed file.</p>
 
 <h2>Data Access</h2>
@@ -222,7 +222,7 @@ tracks</a>. There are three different types of view sub tracks in this track:</a
 <p><b>BAM Reads:</b> Alignable regions are shown in black, unalignable regions
 between two alignable ones shown with thin lines. For configuration options,
 see <a href="https://genome.ucsc.edu/goldenpath/help/hgBamTrackHelp.html">the
-BAM tracks help page</a>. By default, these tracks are hideen, set any of them to "squish" or "pack" (=clickable) on the track configuration page to see the reads. Click reads to show the alignment and read group.</p>
+BAM tracks help page</a>. By default, these tracks are hidden, set any of them to "squish" or "pack" (=clickable) on the track configuration page to see the reads. Click reads to show the alignment and read group.</p>
 
 <p><b>Coverage:</b> bar graphs indicate the number of reads at this base pair.
 You may want to switch on auto-scaling of the y axis. For configuration

--- a/src/cbPyLib/cellbrowser/sampleConfig/cellbrowser.conf
+++ b/src/cbPyLib/cellbrowser/sampleConfig/cellbrowser.conf
@@ -44,7 +44,7 @@ meta="meta.tsv"
 # metaDesc = "metaDesc.tsv"
 
 # we try to auto-detect the field type of fields in the meta data.
-# Sometimes, this doesn't work, e.g. when your cluster ID is a numer
+# Sometimes, this doesn't work, e.g. when your cluster ID is a number
 # or your C1 chip ID is a number, but you don't want them binned, you want
 # to treat as if they were categories
 enumFields = ["c1_cell_id"]

--- a/src/cbPyLib/cellbrowser/sampleConfig/desc.conf
+++ b/src/cbPyLib/cellbrowser/sampleConfig/desc.conf
@@ -45,7 +45,7 @@ Please edit desc.conf to change this text or comment out the methods= line and c
 # ena_project = "ENAP12341"
 # SRA accession
 # sra_study = "xxxx"
-# NBCI Bioproject acccession
+# NBCI Bioproject accession
 # bioproject = "xxxx"
 # Others:
 # cirm_dataset= "xxxx"

--- a/src/cbPyLib/cellbrowser/sampleConfig/hub.conf
+++ b/src/cbPyLib/cellbrowser/sampleConfig/hub.conf
@@ -7,11 +7,11 @@ ucscDb = "hg38" # UCSC genome ID for the track hub
 # The necessary files will be automatically downloaded from there into ~/cellbrowserData on the first run
 # You can use the command "cbGenes avail" to show all available identifier <-> symbol mapping tables
 # For all gencode versions, "gencode-human" or "gencode-mouse" should work.
-# Use the value "symbols" to just accept the gene identifer strings as they are
+# Use the value "symbols" to just accept the gene identifier strings as they are
 # Use "auto" to guess the type automatically 
 geneIdType = "symbols"
 
-# the second important part is the mapping of gene identifers or symbols to chromosome locations
+# the second important part is the mapping of gene identifiers or symbols to chromosome locations
 # Example values are "gencode28" or "gencode35". They are BED6 (or more) .bed.gz files, in the format <db>.<geneModel>.bed.gz
 # e.g. hg38.gencode28.bed.gz and we provide a lot of them on http://cells.ucsc.edu/downloads/cellbrowserData/genes/ 
 # They will be automatically downloaded from there into ~/cellbrowserData. 

--- a/ucsc/addTags
+++ b/ucsc/addTags
@@ -97,7 +97,7 @@ for line in dfh:
                     newVal = splitLine[n]
                     if dataType=="list":
                         #vals = splitLine[n].strip().split(',')
-                        # code adapated from https://stackoverflow.com/questions/4071396/split-by-comma-and-strip-whitespace-in-python
+                        # code adapted from https://stackoverflow.com/questions/4071396/split-by-comma-and-strip-whitespace-in-python
                         vals = [x.strip() for x in newVal.split(',')]
                         valStr = str(vals)
                     elif dataType=="str":
@@ -134,7 +134,7 @@ for line in dfh:
                     # find those tags we've referenced in the header
                     if confTag == tag:
                         # take the values from datasetFile and add to output string
-                        # code adapated from https://stackoverflow.com/questions/4071396/split-by-comma-and-strip-whitespace-in-python
+                        # code adapted from https://stackoverflow.com/questions/4071396/split-by-comma-and-strip-whitespace-in-python
                         oldVal = splitTag[1].strip()
                         if "[" in oldVal:
                             vals = [x.strip() for x in splitLine[n].split(',')]

--- a/ucsc/generateAnnouncement
+++ b/ucsc/generateAnnouncement
@@ -4,7 +4,7 @@ import argparse, pathlib
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    description="Creates blocks of html code for dataset annoucements.")
+    description="Creates blocks of html code for dataset announcements.")
 parser.add_argument('dataDescFile', type=str, help='Two column \
 file (csv or tsv). Column 1 is dataset name (e.g. cortex-dev). Column 2 is a short \
 description of that dataset (should be a single sentence)')

--- a/ucsc/makeCbHub
+++ b/ucsc/makeCbHub
@@ -46,7 +46,7 @@ if len(dsList) == 0:
 
 colors = dict()
 if args.colors:
-    # get suffix of colors file to know delimeter, i.e. tab-sep vs comma-sep
+    # get suffix of colors file to know delimiter, i.e. tab-sep vs comma-sep
     # From https://stackoverflow.com/questions/541390/extracting-extension-from-filename-in-python
     cFtype = pathlib.Path(args.colors).suffix
     if cFtype == ".csv":

--- a/ucsc/makeDatasetList
+++ b/ucsc/makeDatasetList
@@ -83,11 +83,11 @@ def main():
             final_index = int(len(fsplit)-2)
             # Had to do this next part in two lines as I couldn't get slicing to work on one line
             # This gets rid of the /usr/local/apache/htdocs-cells bit
-            indicies = fsplit[5:]
+            indices = fsplit[5:]
             # This gets ride of the /dataset.json at the end
-            indicies = indicies[:-1]
+            indices = indices[:-1]
             # from https://stackoverflow.com/questions/12453580/how-do-i-concatenate-items-in-a-list-to-a-single-string
-            dname = '/'.join(indicies)
+            dname = '/'.join(indices)
             # I think at least one of the entries is empty, so skip over that
             if dname != '':
                 # Check to see if an RR dataset is has a desc/cellbrowser.conf file on hgwdev

--- a/ucsc/tabulate_facets.pl
+++ b/ucsc/tabulate_facets.pl
@@ -116,7 +116,7 @@ my %assays = ();
 # In Perl each subdocument is converted into a hash, and a key named 'name'
 # contains the cellBrowser "dataset name"
 # 
-# There _may_ alos be key => value pairs:
+# There _may_ also be key => value pairs:
 # "body_parts": [
 #    "brain"
 #  ],
@@ -174,7 +174,7 @@ sub extract_facets {
     # The Global hashes are actually hashes of array references
     # here the hash key is the _value_ from the JSON facet, and
     # the hash value we store is a an array of all the dataset
-    # names that use this specific value (technicaly, an array reference)
+    # names that use this specific value (technically, an array reference)
     foreach my $value ( @facet_list ) {
         push( @{ ${$dsc_of{$facet}}{$value} }, $name );
     }


### PR DESCRIPTION
Add codespell configuration and fix existing typos.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to over a hundred of projects already mostly with a positive feedback
(see the ["improveit-dashboard"](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).

The GitHub Actions CI workflow has `permissions` set only to `read`, so it is safe.

## Changes

### Configuration & Infrastructure
- Added `.codespellrc` with skip patterns for vendored JavaScript libraries
  (`*/ext/*`, `*/node_modules/*`), gene-annotation reference data
  (`*/cellbrowserData/*`, `*/cbWeb/genes/*`), sample data (`*/sampleData/*`),
  generated artifacts (`versioneer.py`, `*/_version.py`, `*/build/*`,
  `docs/_build/*`, `docs/build/*`), the vendored EZID CLI from CDL
  (`*/ucsc/ezid.py`), local `.git-meta/` worktrees, and binary/data
  filetypes (PDF/SVG/PNG/JPG/CSS/min.*, TSV/CSV/JSON/JSON.gz, fonts, h5ad,
  rds, .tags, .sizes).
- Created `.github/workflows/codespell.yml` to check spelling on push and PRs
  to `develop`. Uses `codespell-project/actions-codespell@v2` pinned by SHA.
  `permissions: contents: read` only.

### Domain-Specific Whitelist
- `ore` — JavaScript regex variable name (`ore = /^0/`) in the natural-sort
  code in `cellBrowser.js`. Documented inline in `.codespellrc`.

### Typo Fixes

**Ambiguous typos fixed manually** (5 fixes with context review):
- `interative` → `interactive` (`README.rst:43`)
- `fo` → `of` (`docs/howto.rst:23` — "RDS file fo your dataset")
- `installion` → `installation` (`docs/scanpy.rst:14`)
- `recusively` → `recursively` (`cellbrowser.py:6798`, in a commented-out block)
- `strin` → `string` (`cbData.js:236`, in a comment)

**False positives protected with inline `codespell:ignore` pragmas**:
- `nd` (the "not determined" abbreviation in two `emptyVals` /
  `likeEmptyString` lists) — `cellbrowser.py:1143`, `cellBrowser.js:6380`

**Non-ambiguous typos fixed automatically** via `codespell -w` (committed via
`datalad run` for reproducibility) — 50+ fixes across docs, Python, JS,
config files, and the `ucsc/` scripts. Notable patterns:
- `coordiante(s)` / `coordinats` → `coordinate(s)` (×6)
- `substract` → `subtract` (×4)
- `indicies` → `indices` (×4, including variable renames in
  `ucsc/makeDatasetList`)
- `relase` → `release` (×4)
- `configue` → `configure` (×2)
- `re-use` → `reuse` (×2)
- Various one-offs: `utilties`, `folllowing`, `colum`, `chnages`, `Couldnt`,
  `Jupyther`, `instread`, `likly`, `implicitely`, `gziped`, `expresssion`,
  `hideen`, `reponse`, `identifer(s)`, `readble`, `endianess`,
  `compresssion`, `somtimes`, `overriden`, `specfied`, `necesssary`,
  `pre-selected`, `pallette`, `everthing`, `Attribue`, `antialising`,
  `Initialiaze`, `numer`, `acccession`, `adapated`, `annoucements`,
  `delimeter`, `alos`, `technicaly`.

### Historical Context
This project has had **41 prior commits** mentioning typo / spelling /
spell fixes — many of them small, one-line follow-ups (`git log
--oneline --all --grep=typo --grep=spell --grep=spelling`). Automating
this in CI catches them at PR time instead.

## Testing

- `uvx codespell` passes with zero errors after all fixes.
- Python source files (`cellbrowser.py`, `convert.py`, `genes.py`,
  `hubmaker.py`) still parse with `ast.parse`.
- JS files still parse with `node -c`.
- Function names and JS XHR/DOM properties were not touched; only their
  surrounding comments and user-facing string literals.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
